### PR TITLE
Type safety for # of function list timepoints

### DIFF
--- a/R/read.R
+++ b/R/read.R
@@ -98,7 +98,7 @@ get_funclist_tpts <- function(inlist) {
             return(hdr$dim[4])
         } else if (inlist$ftype %in% c("space", "tab", "csv")) {
             cmd <- sprintf("wc -l %s | awk '{print $1}'", inlist$files[i])
-            return(system(cmd, intern=T))
+            return(as.integer(system(cmd, intern=T)))
         } else {
             vstop("Cannot read # of time-points for type '%s'", inlist$ftype)
         }


### PR DESCRIPTION
Make sure that the number of timepoints for a set of functional files is an integer (rather than a character vector) for files read in via a csv file.