### PR TITLE
Fix Error non-numeric argument to binary operator

### DIFF
--- a/R/memlimit.R
+++ b/R/memlimit.R
@@ -16,7 +16,7 @@ get_subdist_memlimit <- function(opts, nsubs, nvoxs, subs.ntpts, nvoxs2=NULL,
     mem_limit <- as.numeric(opts$memlimit)
     
     # RAM for functionals
-    mem_used4func <- sum(sapply(subs.ntpts, function(x) n2gb(x*nvoxs)))
+    mem_used4func <- sum(sapply(subs.ntpts, function(x) n2gb(as.numeric(x)*nvoxs)))
     if (!is.null(nvoxs2)) {
         vcat(opts$verbose, "...%.2f GB used for 1st set of functional data", mem_used4func)
         mem_used4func2 <- sum(sapply(subs.ntpts, function(x) n2gb(x*nvoxs2)))


### PR DESCRIPTION
Traced a problem to memlimit.R:19 when using ROI text files; inputs were being read as non-numeric. This patch coerces inputs to numeric for the `get_subdist_memlimit` function for calculating memory requirements.

Full output with error:

```
connectir_subdist.R -i functional_path_list.txt --in2D2 --ztransform --bg ~/Downloads/connectir/data/standard_4mm.nii.gz --memlimit 4 --overwrite test_output

Loading niftir version < 1.0.

Setting 1 parallel forks
Setting 1 threads for matrix algebra operations
...using Intel's MKL
Checking required inputs
Checking optional inputs
...NOT using 2nd set of functional images
Preparing functional information

Preparing functionals
Preparing functional info
Preparing functional information

Computing brain mask
final mask has 100.00% non-zero voxels
Memory?
Determining memory demands

An error was detected: 
non-numeric argument to binary operator 

Called by: 
x * nvoxs

Saving options...

Removing everything from memory
...sucesss
```