### PR TITLE
Typo in save_mdmr.formula and save_mdmr.factors

### DIFF
--- a/R/mdmr.R
+++ b/R/mdmr.R
@@ -347,14 +347,14 @@ save_mdmr.modelinfo <- function(mdir, modelinfo)
 save_mdmr.formula <- function(mdir, modelinfo)
 {
     ofile <- file.path(mdir, "formula.txt")
-    cat(as.character(modelinfo$formula)[-c(1:2)], file=ofile)
+    cat(as.character(modelinfo$formula)[-c(1)], file=ofile)
 }
 
 save_mdmr.factors <- function(mdir, modelinfo)
 {
     ofile <- file.path(mdir, "factor_names.txt")
     
-    all.factornames <- names(attr(modelinfo$qrhs, "factors.names"))
+    all.factornames <- names(attr(modelinfo$qrhs, "factor.names"))
     perm.factornames <- names(attr(modelinfo$qrhs, "factors2perm"))
     is <- !(all.factornames %in% perm.factornames)
     cov.factornames <- all.factornames[is]


### PR DESCRIPTION
as.character(modelinfo$formula) is empty due to elimination of all 2 elements. Saving factor names should call the attribute "factor.names" of modelinfo$qhrs, not "factors.names".